### PR TITLE
Fix #35: make getFilename works correctly

### DIFF
--- a/core/clang-plugin.cc
+++ b/core/clang-plugin.cc
@@ -155,8 +155,9 @@ bool ffi::ffiASTConsumer::HandleTopLevelDecl(DeclGroupRef decls) {
         in which case the declarations won't be
         found for the ffi. */
 bool ffi::ffiASTConsumer::topLevelHeaderContains(Decl *d) {
-  std::string filename =
-    compiler.getSourceManager().getFilename(d->getLocation()).str();
+  SourceManager& srcManager = compiler.getSourceManager();
+  SourceLocation srcLoc = srcManager.getSpellingLoc(d->getLocation());
+  std::string filename = srcManager.getFilename(srcLoc).str();
   return accumulator.sources.count(filename);
 }
 


### PR DESCRIPTION
The argument to getFilename must be a SpellingLoc according to
https://clang.llvm.org/doxygen/SourceManager_8h_source.html#l01096.
Therefore, convert the input source location to a spelling location first.