### PR TITLE
Update to LLVM 11

### DIFF
--- a/core/clang-plugin.cc
+++ b/core/clang-plugin.cc
@@ -71,7 +71,7 @@ c_decl_array dynamic_ffi_parse(int argc, const char **argv, int deep_parse) {
     unsigned len = strlen(argv[i]);
     SmallString<sizeof(char)> st(argv[i], argv[i] + sizeof(char) *len);
     sys::fs::make_absolute(st);
-    source_list.push_back(st.str());
+    source_list.push_back(st.str().str());
   }
 
   ClangTool tool(*DB, (ArrayRef<std::string>) source_list);

--- a/core/clang-plugin.hh
+++ b/core/clang-plugin.hh
@@ -89,7 +89,7 @@ protected:
   std::unique_ptr<ASTConsumer>
     CreateASTConsumer(CompilerInstance &compiler,
                       llvm::StringRef) override {
-      return llvm::make_unique<ffiASTConsumer>(accumulator, compiler, deep_parse);
+      return std::make_unique<ffiASTConsumer>(accumulator, compiler, deep_parse);
     }
 };
 
@@ -102,8 +102,8 @@ newFFIActionFactory(ffiAccumulator &accumulator, bool deep_parse) {
   public:
     ffiActionFactory(ffiAccumulator &accumulator, bool deep_parse)
       : accumulator(accumulator), deep_parse(deep_parse) {}
-    FrontendAction *create() override {
-      return new T(accumulator, deep_parse);
+    std::unique_ptr<FrontendAction> create() override {
+      return std::unique_ptr<T>(new T(accumulator, deep_parse));
     }
   };
   return std::unique_ptr<FrontendActionFactory>(new ffiActionFactory(accumulator, deep_parse));


### PR DESCRIPTION
A few small changes to support LLVM 11.

If you are willing to give me some pointers, I would love to add support for Racket on Chez Scheme.

Thanks for the great library.